### PR TITLE
Make auth server port configurable via AUTH_PORT env var

### DIFF
--- a/src/auth-server.ts
+++ b/src/auth-server.ts
@@ -28,7 +28,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 const app = express()
-const port = 3000
+const port = parseInt(process.env.AUTH_PORT || "3000")
 const TOKEN_FILE_PATH = join(process.cwd(), "tokens.json")
 
 // Determine the tenant ID to use:


### PR DESCRIPTION
## Summary
- Allows configuring the auth server port via the `AUTH_PORT` environment variable
- Defaults to port 3000 (no breaking change)
- Useful when port 3000 is already in use (e.g. by VS Code Remote Server)

## Test plan
- Set `AUTH_PORT=3002` in `.env` and verify auth server starts on port 3002
- Verify default behavior (no `AUTH_PORT` set) still uses port 3000