### PR TITLE
Add recurrence support and expose read-only task fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Model Context Protocol (MCP) server that enables AI assistants like Claude and
 
 ## Features
 
-- **15 MCP Tools**: Complete task management functionality including lists, tasks, checklist items, and organization features
+- **16 MCP Tools**: Complete task management functionality including lists, tasks, checklist items, bulk archiving, and organization features
 - **Seamless Authentication**: Automatic token refresh with zero manual intervention
 - **OAuth 2.0 Authentication**: Secure authentication with automatic token refresh
 - **Microsoft Graph API Integration**: Direct integration with Microsoft's official API
@@ -207,7 +207,7 @@ pnpm run typecheck    # TypeScript type checking
 
 ## MCP Tools
 
-The server provides 13 tools for comprehensive Microsoft To Do management:
+The server provides 16 tools for comprehensive Microsoft To Do management:
 
 ### Authentication
 
@@ -216,6 +216,7 @@ The server provides 13 tools for comprehensive Microsoft To Do management:
 ### Task Lists (Top-level Containers)
 
 - **`get-task-lists`** - Retrieve all task lists with metadata (default, shared, etc.)
+- **`get-task-lists-organized`** - Get all task lists organized into logical folders/categories based on naming patterns, emoji prefixes, and sharing status. Supports grouping by `category`, `shared`, or `type`
 - **`create-task-list`** - Create a new task list
 - **`update-task-list`** - Rename an existing task list
 - **`delete-task-list`** - Delete a task list and all its contents
@@ -235,6 +236,10 @@ The server provides 13 tools for comprehensive Microsoft To Do management:
 - **`create-checklist-item`** - Add a new subtask to a task
 - **`update-checklist-item`** - Update subtask text or completion status
 - **`delete-checklist-item`** - Remove a specific subtask
+
+### Bulk Operations
+
+- **`archive-completed-tasks`** - Move completed tasks older than a specified number of days from one list to an archive list. Supports dry-run mode to preview what would be archived before committing changes
 
 ## Architecture
 

--- a/src/todo-index.ts
+++ b/src/todo-index.ts
@@ -250,12 +250,34 @@ interface TaskList {
   wellknownListName?: string // 'none', 'defaultList', 'flaggedEmails', 'unknownFutureValue'
 }
 
+interface RecurrencePattern {
+  type: "daily" | "weekly" | "absoluteMonthly" | "relativeMonthly" | "absoluteYearly" | "relativeYearly"
+  interval: number
+  daysOfWeek?: string[]
+  dayOfMonth?: number
+  weekIndex?: "first" | "second" | "third" | "fourth" | "last"
+  month?: number
+  firstDayOfWeek?: string
+}
+
+interface RecurrenceRange {
+  type: "endDate" | "noEnd" | "numbered"
+  startDate: string
+  endDate?: string
+  numberOfOccurrences?: number
+  recurrenceTimeZone?: string
+}
+
 interface Task {
   id: string
   title: string
   status: string
   importance: string
   dueDateTime?: {
+    dateTime: string
+    timeZone: string
+  }
+  startDateTime?: {
     dateTime: string
     timeZone: string
   }
@@ -272,6 +294,14 @@ interface Task {
     contentType: string
   }
   categories?: string[]
+  recurrence?: {
+    pattern: RecurrencePattern
+    range: RecurrenceRange
+  }
+  createdDateTime?: string
+  lastModifiedDateTime?: string
+  bodyLastModifiedDateTime?: string
+  hasAttachments?: boolean
 }
 
 interface ChecklistItem {
@@ -887,6 +917,11 @@ server.tool(
           taskInfo = `${status} ${taskInfo}`
         }
 
+        // Add start date if available
+        if (task.startDateTime) {
+          taskInfo += `\nStart: ${new Date(task.startDateTime.dateTime).toLocaleDateString()}`
+        }
+
         // Add due date if available
         if (task.dueDateTime) {
           taskInfo += `\nDue: ${new Date(task.dueDateTime.dateTime).toLocaleDateString()}`
@@ -902,6 +937,24 @@ server.tool(
           taskInfo += `\nCategories: ${task.categories.join(", ")}`
         }
 
+        // Add recurrence if available
+        if (task.recurrence) {
+          const p = task.recurrence.pattern
+          const r = task.recurrence.range
+          const rangeDesc =
+            r.type === "endDate"
+              ? ` until ${r.endDate}`
+              : r.type === "numbered"
+                ? ` for ${r.numberOfOccurrences} occurrences`
+                : " (no end)"
+          taskInfo += `\nRecurrence: every ${p.interval} ${p.type}${rangeDesc}`
+        }
+
+        // Add attachments flag if present
+        if (task.hasAttachments) {
+          taskInfo += `\nHas Attachments: yes`
+        }
+
         // Add body content if available and not empty
         if (task.body && task.body.content && task.body.content.trim() !== "") {
           const previewLength = 50
@@ -910,6 +963,15 @@ server.tool(
               ? task.body.content.substring(0, previewLength) + "..."
               : task.body.content
           taskInfo += `\nDescription: ${contentPreview}`
+        }
+
+        // Add timestamps if available
+        if (task.createdDateTime) {
+          taskInfo += `\nCreated: ${new Date(task.createdDateTime).toLocaleString()}`
+        }
+
+        if (task.lastModifiedDateTime) {
+          taskInfo += `\nModified: ${new Date(task.lastModifiedDateTime).toLocaleString()}`
         }
 
         return `${taskInfo}\n---`
@@ -959,6 +1021,27 @@ server.tool(
       .optional()
       .describe("Status of the task"),
     categories: z.array(z.string()).optional().describe("Categories associated with the task"),
+    recurrence: z
+      .object({
+        pattern: z.object({
+          type: z.enum(["daily", "weekly", "absoluteMonthly", "relativeMonthly", "absoluteYearly", "relativeYearly"]),
+          interval: z.number().int().min(1),
+          daysOfWeek: z.array(z.string()).optional(),
+          dayOfMonth: z.number().int().optional(),
+          weekIndex: z.enum(["first", "second", "third", "fourth", "last"]).optional(),
+          month: z.number().int().optional(),
+          firstDayOfWeek: z.string().optional(),
+        }),
+        range: z.object({
+          type: z.enum(["endDate", "noEnd", "numbered"]),
+          startDate: z.string().describe("Start date in YYYY-MM-DD format"),
+          endDate: z.string().optional().describe("End date in YYYY-MM-DD format (required when type is endDate)"),
+          numberOfOccurrences: z.number().int().optional().describe("Number of occurrences (required when type is numbered)"),
+          recurrenceTimeZone: z.string().optional(),
+        }),
+      })
+      .optional()
+      .describe("Recurrence pattern for repeating tasks"),
   },
   async ({
     listId,
@@ -971,6 +1054,7 @@ server.tool(
     reminderDateTime,
     status,
     categories,
+    recurrence,
   }) => {
     try {
       const token = await getAccessToken()
@@ -1033,6 +1117,10 @@ server.tool(
         taskBody.categories = categories
       }
 
+      if (recurrence) {
+        taskBody.recurrence = recurrence
+      }
+
       const response = await makeGraphRequest<Task>(
         `${MS_GRAPH_BASE}/me/todo/lists/${listId}/tasks`,
         token,
@@ -1090,6 +1178,28 @@ server.tool(
       .optional()
       .describe("New status of the task"),
     categories: z.array(z.string()).optional().describe("New categories associated with the task"),
+    recurrence: z
+      .object({
+        pattern: z.object({
+          type: z.enum(["daily", "weekly", "absoluteMonthly", "relativeMonthly", "absoluteYearly", "relativeYearly"]),
+          interval: z.number().int().min(1),
+          daysOfWeek: z.array(z.string()).optional(),
+          dayOfMonth: z.number().int().optional(),
+          weekIndex: z.enum(["first", "second", "third", "fourth", "last"]).optional(),
+          month: z.number().int().optional(),
+          firstDayOfWeek: z.string().optional(),
+        }),
+        range: z.object({
+          type: z.enum(["endDate", "noEnd", "numbered"]),
+          startDate: z.string().describe("Start date in YYYY-MM-DD format"),
+          endDate: z.string().optional().describe("End date in YYYY-MM-DD format (required when type is endDate)"),
+          numberOfOccurrences: z.number().int().optional().describe("Number of occurrences (required when type is numbered)"),
+          recurrenceTimeZone: z.string().optional(),
+        }),
+      })
+      .nullable()
+      .optional()
+      .describe("Recurrence pattern. Set to null to remove recurrence from the task."),
   },
   async ({
     listId,
@@ -1103,6 +1213,7 @@ server.tool(
     reminderDateTime,
     status,
     categories,
+    recurrence,
   }) => {
     try {
       const token = await getAccessToken()
@@ -1182,6 +1293,11 @@ server.tool(
 
       if (categories !== undefined) {
         taskBody.categories = categories
+      }
+
+      if (recurrence !== undefined) {
+        // null removes recurrence; an object sets it
+        taskBody.recurrence = recurrence
       }
 
       // Make sure we have at least one property to update


### PR DESCRIPTION
- Add RecurrencePattern and RecurrenceRange interfaces
- Add recurrence parameter to create-task and update-task tools
- Add startDateTime, createdDateTime, lastModifiedDateTime, bodyLastModifiedDateTime, hasAttachments to Task interface
- Display start date, recurrence summary, attachments flag, and timestamps in get-tasks output