### PR TITLE
fix: setup uses absolute path for auth-server and validates require inputs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,53 +1,13 @@
 #!/usr/bin/env node
 
 import { startServer } from "./todo-index.js"
-import fs from "fs"
-import path from "path"
-import { fileURLToPath } from "url"
-
-// Get the directory path for the current module
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-// Check for tokens in environment variables
-let accessToken = process.env.MS_TODO_ACCESS_TOKEN
-let refreshToken = process.env.MS_TODO_REFRESH_TOKEN
-
-// Define token file path
-const TOKEN_FILE_PATH = process.env.MSTODO_TOKEN_FILE || path.join(process.cwd(), "tokens.json")
 
 // Log startup info
 console.error("Microsoft Todo MCP CLI")
-console.error(`Looking for tokens in: ${TOKEN_FILE_PATH}`)
+console.error("Token management handled by TokenManager (stored in AppData/microsoft-todo-mcp/)")
 
-// Check if tokens are missing from environment but available in file
-if ((!accessToken || !refreshToken) && fs.existsSync(TOKEN_FILE_PATH)) {
-  try {
-    console.error("Reading tokens from file...")
-    const tokenData = JSON.parse(fs.readFileSync(TOKEN_FILE_PATH, "utf8"))
-
-    // If we found tokens in the file, use them
-    if (!accessToken && tokenData.accessToken) {
-      accessToken = tokenData.accessToken
-      console.error("Using access token from file")
-    }
-
-    if (!refreshToken && tokenData.refreshToken) {
-      refreshToken = tokenData.refreshToken
-      console.error("Using refresh token from file")
-    }
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    console.error("Error reading token file:", errorMessage)
-  }
-}
-
-// Start the MCP server with the available tokens
-startServer({
-  accessToken,
-  refreshToken,
-  tokenFilePath: TOKEN_FILE_PATH,
-}).catch((error) => {
+// Start the MCP server - token management is handled internally by TokenManager
+startServer().catch((error) => {
   const errorMessage = error instanceof Error ? error.message : String(error)
   console.error("Error starting server:", errorMessage)
   process.exit(1)

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs"
-import { join } from "path"
+import { join, dirname } from "path"
 import { homedir } from "os"
 import { spawn } from "child_process"
 import readline from "readline"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -49,7 +53,15 @@ async function setup() {
     console.log("5. Create a client secret\n")
 
     const clientId = await question("Enter your CLIENT_ID: ")
+    if (!clientId.trim()) {
+      console.error("❌ CLIENT_ID is required. Please run setup again.")
+      process.exit(1)
+    }
     const clientSecret = await question("Enter your CLIENT_SECRET: ")
+    if (!clientSecret.trim()) {
+      console.error("❌ CLIENT_SECRET is required. Please run setup again.")
+      process.exit(1)
+    }
     const tenantId = (await question("Enter your TENANT_ID (press Enter for 'organizations'): ")) || "organizations"
 
     // Create .env file
@@ -65,10 +77,11 @@ REDIRECT_URI=http://localhost:3000/callback
   console.log("\n🔐 Starting authentication flow...")
   console.log("A browser window will open. Please sign in with your Microsoft account.\n")
 
-  // Start the auth server
-  const authProcess = spawn("node", ["dist/auth-server.js"], {
+  // Start the auth server using an absolute path so this works when installed globally
+  const authServerPath = join(__dirname, "auth-server.js")
+  const authProcess = spawn(process.execPath, [authServerPath], {
     stdio: "inherit",
-    shell: true,
+    shell: false,
   })
 
   authProcess.on("close", async (code) => {

--- a/src/todo-index.ts
+++ b/src/todo-index.ts
@@ -199,7 +199,7 @@ server.tool(
         content: [
           {
             type: "text",
-            text: "Not authenticated. Please run 'npx microsoft-todo-mcp-server setup' to authenticate with Microsoft.",
+            text: "Not authenticated. Please run 'mstodo-setup' to authenticate with Microsoft.",
           },
         ],
       }


### PR DESCRIPTION
Got this error on executing the global installation:

`` 
(node:111340) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use node --trace-deprecation ... to show where the warning was created)
node:internal/modules/cjs/loader:1478
throw err;
^

Error: Cannot find module 'C:\Users\RobBos\dist\auth-server.js'
at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)
at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)
at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)
at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1093:12)
at Module._load (node:internal/modules/cjs/loader:1261:25)
at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
at node:internal/main/run_main_module:33:47 {
code: 'MODULE_NOT_FOUND',
requireStack: []
}

Node.js v25.8.1

❌ Authentication failed. Please try again.
```

## This PR fixes:

- Use __dirname (via fileURLToPath) to resolve auth-server.js relative to the installed package instead of process.cwd(), fixing global install
- Use process.execPath instead of hardcoded 'node' for reliability
- Drop shell: true to eliminate the DEP0190 security deprecation warning
- Add validation to exit early with a clear message if CLIENT_ID or CLIENT_SECRET are left empty