### PR TITLE
chore: bump ts-builds to ^3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/node": "^22.19.21",
-    "ts-builds": "3.1.1",
+    "ts-builds": "^3.2.0",
     "tsdown": "^0.22.2"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^22.19.21
         version: 22.19.21
       ts-builds:
-        specifier: 3.1.1
-        version: 3.1.1(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(tsdown@0.22.2(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.21))
+        specifier: ^3.2.0
+        version: 3.2.0(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(tsdown@0.22.2(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.21))
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(typescript@6.0.3)
@@ -1585,8 +1585,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-builds@3.1.1:
-    resolution: {integrity: sha512-JUve4D+cxisTVDv91jG1d5Z3U+/wSw3hoFXh+7BnS9Swx9NZw7NBBJalOkz95+wg4QXUpdBgTmYr3xC0MSzh7w==}
+  ts-builds@3.2.0:
+    resolution: {integrity: sha512-Ulv0s+TYrWKNzMNvAO6j/RFmoH9EfRibsWVHJlmNxbJJg9cxTDgu2/JcZkjFYpP3EJ7VOpgsJyty+156TOIWcQ==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -3298,7 +3298,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-builds@3.1.1(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(tsdown@0.22.2(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.21)):
+  ts-builds@3.2.0(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(tsdown@0.22.2(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.21)):
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@types/node': 24.10.15


### PR DESCRIPTION
Bumps the `ts-builds` devDependency from `3.1.1` to `^3.2.0`.

3.2.0 ([ts-builds#97](https://github.com/jordanburke/ts-builds/pull/97)) adds `globals` to the `init`-seeded hoist patterns and collapses first-party release-age excludes to a `*functype*` glob — the fixes that came out of this repo's migration.

`ts-builds` is listed in `minimumReleaseAgeExclude`, so the just-published release installs without tripping the pnpm 11 cooldown. Verified: `pnpm install --frozen-lockfile` and `pnpm validate` both pass (lint 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)