### PR TITLE
docs: note ts-builds 3.2.0 / pnpm 11 quirks in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,17 @@ pnpm run cli         # Run MCP server via CLI wrapper
 pnpm start           # Run MCP server directly
 ```
 
+## ts-builds & pnpm 11 Notes
+
+Built with **ts-builds 3.2.0** (tsdown) on **pnpm 11**. Non-obvious, load-bearing constraints:
+
+- **Node >= 22.13 required.** pnpm 11 crashes on Node 20 (`ERR_UNKNOWN_BUILTIN_MODULE`). CI runs Node 22.x/24.x; the publish workflow uses Node 24 (`.nvmrc`).
+- **Keep `globals` in `publicHoistPattern`** (`pnpm-workspace.yaml`). `eslint.config.js` imports `globals`, which `*eslint*` does not match. Without the explicit hoist line, resolution falls back to pnpm's incidental `.pnpm` virtual-store hoist — passes locally but **fails CI** with `Cannot find package 'globals'`. It is load-bearing, not redundant; ts-builds 3.2.0 only adds it for _new_ `init`s, it does not retro-fit this file.
+- **First-party release-age excludes are globs, not pins.** `minimumReleaseAgeExclude` is `*functype*` + `ts-builds`. `pnpm add` auto-adds per-version pins for first-party packages within the 24h cooldown — collapse them back to the glob (pins re-trip on every release).
+- **`allowBuilds: esbuild: false`** is required under pnpm 11 `strictDepBuilds` (esbuild's binary ships via `@esbuild/<platform>` optional deps; build script not needed).
+- **tsdown emits `.js`, not `.mjs`.** `tsdown.config.ts` forces `outExtensions: () => ({ js: ".js" })` so the `bin`/`main` paths and `./*.js` imports resolve. Don't drop it.
+- **`pnpm install` in a non-TTY shell** may abort with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` — prefix with `CI=true`. Note `CI=true` makes `--frozen-lockfile` the default, so add `--no-frozen-lockfile` when intentionally updating the lockfile.
+
 ## Architecture Overview
 
 This is a Model Context Protocol (MCP) server that enables AI assistants to interact with Microsoft To Do via the Microsoft Graph API. The codebase follows a modular architecture with four main components:


### PR DESCRIPTION
Adds a **ts-builds & pnpm 11 Notes** section to `CLAUDE.md` capturing the load-bearing, non-obvious constraints surfaced during the migration so they aren't re-broken:

- Node >= 22.13 (pnpm 11 crashes on Node 20); CI on 22/24, publish on 24
- The `globals` `publicHoistPattern` line is **load-bearing** (eslint.config.js import; fails CI without it) — not redundant
- First-party `minimumReleaseAgeExclude` are globs (`*functype*` + `ts-builds`), not per-version pins
- `allowBuilds: esbuild: false` under pnpm 11 `strictDepBuilds`
- tsdown forced to `.js` output via `outExtensions`
- `CI=true` for the non-TTY `pnpm install` abort (+ the `--no-frozen-lockfile` follow-on)

Docs only. CLAUDE.md passes `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)