### PR TITLE
fix(token-manager): keep personal (MSA) accounts authenticated (IDX14100 + stale env seed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ export MS_TODO_ACCESS_TOKEN=your_access_token
 export MS_TODO_REFRESH_TOKEN=your_refresh_token
 ```
 
+> **Personal Microsoft accounts (`TENANT_ID=consumers`):** token refresh requests fully-qualified Microsoft Graph scopes (e.g. `https://graph.microsoft.com/Tasks.ReadWrite`). Bare scope names make Graph reject the refreshed token with `IDX14100` ("JWT is not well formed") — the failure mode where the server works on day one and returns 401s afterwards.
+>
+> **Env-token setups refresh on startup.** With `MS_TODO_ACCESS_TOKEN` / `MS_TODO_REFRESH_TOKEN` set, the seed access token is refreshed on first use (and cached until it expires) rather than trusted for a fixed hour. That refresh needs `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to be set as well; without them the server falls back to using the seed token as-is.
+
 ## Usage
 
 ### Complete Setup Workflow

--- a/src/token-manager.test.ts
+++ b/src/token-manager.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Keep the token manager off the real filesystem: a successful refresh calls
+// saveTokens() (writes tokens.json) and updateClaudeConfig() (may rewrite the
+// Claude desktop config). Mocking fs makes those no-ops — existsSync -> false
+// also short-circuits the Claude-config write — so the test can never clobber a
+// developer's real tokens.json or config.
+vi.mock("fs", () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => "{}"),
+  writeFileSync: vi.fn(),
+}))
+
+import { TokenManager } from "./token-manager.js"
+
+const ENV_KEYS = ["MS_TODO_ACCESS_TOKEN", "MS_TODO_REFRESH_TOKEN", "CLIENT_ID", "CLIENT_SECRET", "TENANT_ID"] as const
+const saved: Record<string, string | undefined> = {}
+
+function okTokenResponse() {
+  return {
+    ok: true,
+    json: async () => ({ access_token: "fresh-access", refresh_token: "fresh-refresh", expires_in: 3600 }),
+    text: async () => "",
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k]
+  process.env.MS_TODO_ACCESS_TOKEN = "seed-access"
+  process.env.MS_TODO_REFRESH_TOKEN = "seed-refresh"
+  process.env.CLIENT_ID = "client-id"
+  process.env.CLIENT_SECRET = "client-secret"
+  process.env.TENANT_ID = "consumers"
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("TokenManager env-seed cold start", () => {
+  it("refreshes the seed once on cold start, then serves the in-process cache", async () => {
+    const fetchMock = vi.fn(async () => okTokenResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const tm = new TokenManager()
+    const first = await tm.getTokens()
+    expect(first?.accessToken).toBe("fresh-access")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // A second call within the cached expiry must not refresh again.
+    const second = await tm.getTokens()
+    expect(second?.accessToken).toBe("fresh-access")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("requests fully-qualified Microsoft Graph scopes (fixes MSA IDX14100)", async () => {
+    let body = new URLSearchParams()
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      body = new URLSearchParams(String(init?.body))
+      return okTokenResponse()
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await new TokenManager().getTokens()
+
+    const scope = body.get("scope") ?? ""
+    expect(scope).toContain("https://graph.microsoft.com/Tasks.ReadWrite")
+    expect(scope.split(" ")).not.toContain("Tasks.ReadWrite") // no bare scope names
+  })
+
+  it("returns the seed token without any network call when client creds are absent", async () => {
+    delete process.env.CLIENT_ID
+    delete process.env.CLIENT_SECRET
+    const fetchMock = vi.fn(async () => okTokenResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const tokens = await new TokenManager().getTokens()
+    expect(tokens?.accessToken).toBe("seed-access")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -18,6 +18,10 @@ interface StoredTokenData extends TokenData {
 export class TokenManager {
   private tokenFilePath: string
   private currentTokens: StoredTokenData | null = null
+  // Epoch ms of the last failed refresh; throttles retries so a dead refresh
+  // token can't trigger a token-endpoint call on every request.
+  private lastRefreshFailedAt = 0
+  private static readonly REFRESH_RETRY_COOLDOWN_MS = 60 * 1000
 
   constructor() {
     // Store tokens in a consistent location across platforms
@@ -39,21 +43,46 @@ export class TokenManager {
   async getTokens(): Promise<TokenData | null> {
     // 1. Check environment variables first (for backward compatibility)
     if (process.env.MS_TODO_ACCESS_TOKEN && process.env.MS_TODO_REFRESH_TOKEN) {
-      const envTokens: TokenData = {
-        accessToken: process.env.MS_TODO_ACCESS_TOKEN,
-        refreshToken: process.env.MS_TODO_REFRESH_TOKEN,
-        expiresAt: Date.now() + 3600 * 1000, // Assume 1 hour if not specified
+      // Reuse a token already refreshed earlier in this process while it is
+      // still valid, so we don't hit the token endpoint on every request.
+      if (this.currentTokens && Date.now() < this.currentTokens.expiresAt) {
+        return this.currentTokens
       }
 
-      // Check if expired
-      if (Date.now() > envTokens.expiresAt) {
-        // Try to refresh
-        const refreshed = await this.refreshToken(envTokens.refreshToken)
+      // The env access token is a one-time seed whose real expiry we don't know
+      // — it may have been minted on a previous day. The old code fabricated a
+      // "now + 1h" expiry, so a stale seed was treated as valid and never
+      // refreshed: env-configured setups worked on day one and 401'd every day
+      // after. Refresh on cold start to always present a valid Graph token.
+      //
+      // Two guards keep this from regressing setups that can't refresh:
+      //   - Skip when client credentials are absent — the v2 token endpoint
+      //     requires them, so an env-only config without CLIENT_ID/CLIENT_SECRET
+      //     keeps its prior behavior of using the seed token as-is.
+      //   - Back off for REFRESH_RETRY_COOLDOWN_MS after a failed refresh so a
+      //     dead refresh token can't hit the token endpoint on every request
+      //     (the 401-retry path would otherwise double the calls).
+      const haveClientCreds = Boolean(
+        (this.currentTokens?.clientId || process.env.CLIENT_ID) &&
+        (this.currentTokens?.clientSecret || process.env.CLIENT_SECRET),
+      )
+      const cooledDown = Date.now() - this.lastRefreshFailedAt > TokenManager.REFRESH_RETRY_COOLDOWN_MS
+      if (haveClientCreds && cooledDown) {
+        const refreshed = await this.refreshToken(process.env.MS_TODO_REFRESH_TOKEN)
         if (refreshed) {
           return refreshed
         }
+        this.lastRefreshFailedAt = Date.now()
       }
-      return envTokens
+
+      // Last resort: hand back the seed token as-is. Leave it marked expired
+      // (don't fabricate a future expiry) so a later call retries the refresh
+      // after the cooldown instead of trusting a possibly-dead token for an hour.
+      return {
+        accessToken: process.env.MS_TODO_ACCESS_TOKEN,
+        refreshToken: process.env.MS_TODO_REFRESH_TOKEN,
+        expiresAt: Date.now(),
+      }
     }
 
     // 2. Check stored token file

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -145,7 +145,16 @@ export class TokenManager {
         client_secret: clientSecret,
         refresh_token: refreshToken,
         grant_type: "refresh_token",
-        scope: "offline_access Tasks.Read Tasks.ReadWrite Tasks.Read.Shared Tasks.ReadWrite.Shared User.Read",
+        // Request fully-qualified Microsoft Graph scope URIs. This is a
+        // hand-rolled refresh (raw form POST, not MSAL), so nothing prepends the
+        // resource the way the initial MSAL auth flow does. Bare scope names
+        // (Tasks.ReadWrite) resolve unreliably for personal (MSA/consumers)
+        // accounts and Graph rejects the refreshed token with IDX14100 ("JWT is
+        // not well formed"). The fully-qualified form is the canonical expansion
+        // of the bare names, so it is equivalent for work/school accounts and
+        // fixes personal ones.
+        scope:
+          "offline_access https://graph.microsoft.com/Tasks.Read https://graph.microsoft.com/Tasks.ReadWrite https://graph.microsoft.com/Tasks.Read.Shared https://graph.microsoft.com/Tasks.ReadWrite.Shared https://graph.microsoft.com/User.Read",
       })
 
       const response = await fetch(tokenEndpoint, {


### PR DESCRIPTION
## Summary

Two fixes so personal (MSA / `TENANT_ID=consumers`) accounts — and any env-token setup — stay authenticated past the first hour/day, plus the repo's first unit test and a short README note.

## Problems

1. **Personal accounts 401 once the access token expires (`IDX14100`).** `refreshToken()` POSTs the `refresh_token` grant by hand (not through MSAL) using **bare** scope names (`Tasks.ReadWrite`, …). For MSA/consumers accounts Graph rejects the refreshed token with `IDX14100 "JWT is not well formed"`, so every Graph call fails after the initial token expires.
2. **Env-seeded tokens never refresh.** When tokens come from `MS_TODO_ACCESS_TOKEN` / `MS_TODO_REFRESH_TOKEN`, `getTokens()` fabricated `expiresAt = now + 1h` for the seed and only refreshed once that *fabricated* time passed. A seed minted on an earlier day was treated as valid, so the server worked on day one and returned 401s every day after.

## Fix

1. Request **fully-qualified** Graph scope URIs on refresh (`https://graph.microsoft.com/Tasks.ReadWrite`, …). Per Microsoft's docs the fully-qualified form is the canonical expansion of a bare scope (`User.Read` is equivalent to `https://graph.microsoft.com/User.Read`), so it is **equivalent for work/school accounts** and fixes the personal-account case.
2. Refresh the env seed on cold start and cache the result in-process until its real expiry (no per-request refresh). Two guards keep this from regressing setups that can't refresh:
   - Skip the refresh when `CLIENT_ID`/`CLIENT_SECRET` are absent — keep prior behavior (use the seed as-is) rather than failing every call.
   - Back off 60s after a failed refresh so a dead refresh token can't hit the token endpoint on every request (the 401-retry path would otherwise double the calls).

## Tests

Adds `src/token-manager.test.ts` — the first spec (vitest config was `passWithNoTests`). Mocks `fetch` and `fs` (no real network or filesystem), covering: cold-start refresh happens once then serves the cache; the refresh request uses fully-qualified scopes and never bare names; with no client credentials `getTokens()` returns the seed and makes zero network calls. `pnpm validate` is green on the Node 22.x/24.x toolchain.

## Notes

- The behavior change is limited to the env-token path; the stored-file path is unchanged.
- No new dependencies.
